### PR TITLE
クラスの修正

### DIFF
--- a/ATMsystem/ATM.java
+++ b/ATMsystem/ATM.java
@@ -80,6 +80,7 @@ public class ATM implements BankTeller{
 		//取引が成立した場合、口座の最終利用日を更新する
 		this.account.setDateOfLastUse(getTransactionDate());
 		this.bankbook.recording();
+		this.falseChecked();
 		this.trade = true;
 	}
 
@@ -91,8 +92,25 @@ public class ATM implements BankTeller{
 		return this.charge;
 	}
 
-	public void trueCharge() {
-		this.charge = true;
+	public void setCharge(int transactionCode) {
+		switch (transactionCode) {
+		case 1 -> {
+			//預入の場合
+			if ((this.transactionAmount < 30_000) && (this.account.getFreeCount() >= this.MAX_FREE_COUNT)) {
+				this.charge = true;
+			} else {
+				this.charge = false;
+			}
+		}
+		case 2 -> {
+			//引出の場合
+			if (this.account.getFreeCount() >= this.MAX_FREE_COUNT) {
+				this.charge = true;
+			} else {
+				this.charge = false;
+			}
+		}
+		}
 	}
 
 	public void falseCharge() {
@@ -235,7 +253,7 @@ public class ATM implements BankTeller{
 				this.sc.nextLine();
 				continue;
 			}
-			this.judge(this.transactionCode);
+			this.setCharge(this.transactionCode);
 			//預入最大限度額を確認
 			if (this.transactionAmount < MIN_AMOUNT || this.transactionAmount > MAX_DEPOSIT_AMOUNT) {
 				System.out.println(MIN_AMOUNT + "～" + MAX_DEPOSIT_AMOUNT + "の間で入力してください");
@@ -256,7 +274,6 @@ public class ATM implements BankTeller{
 				if (this.getCharge()) {
 					this.account.setBalance(this.account.getBalance() - this.HANDLING_CHARGE);
 				}
-				this.falseChecked();
 				this.trueTrade();
 				System.out.println(String.format("%,d", this.transactionAmount) + "円を入金します");
 			}
@@ -264,7 +281,7 @@ public class ATM implements BankTeller{
 		}
 		//入金では３万円以下の場合にカウントする
 		if (this.transactionAmount <= 30_000) {
-			this.account.setFreeCount(this.account.getFreeCount() + 1);
+			this.account.setFreeCount();
 		}
 
 	}
@@ -274,7 +291,7 @@ public class ATM implements BankTeller{
 	public void withdrawal() {
 		if (this.account.getBalance() <= 0) {
 			System.out.println("残高がありません");
-			this.setTransaction("取引はありません");
+			this.setTransaction("取引なし");
 			this.setTransactionCode(0);
 			this.setTransactionAmount(0);
 			return;
@@ -289,7 +306,7 @@ public class ATM implements BankTeller{
 				this.sc.nextLine();
 				continue;
 			}
-			this.judge(this.transactionCode);
+			this.setCharge(this.transactionCode);
 			//引出最大限度額を確認
 			if (this.transactionAmount > MAX_WITHDRAWAL_AMOUNT) {
 				System.out.println(MIN_AMOUNT + "～" + MAX_WITHDRAWAL_AMOUNT + "の間で入力してください");
@@ -315,30 +332,29 @@ public class ATM implements BankTeller{
 				if (this.getCharge()) {
 					this.account.setBalance(this.account.getBalance() - this.HANDLING_CHARGE);
 				}
-				this.falseChecked();
 				this.trueTrade();
 				System.out.println(String.format("%,d", this.transactionAmount) + "円を出金します");
 			}
 			break;
 		}
-		this.account.setFreeCount(this.account.getFreeCount() + 1);
+		this.account.setFreeCount();
 	}
 
 	//手数料が無料の取引回数
-	public void judge(int transactionCode) {
-		switch (transactionCode) {
-		case 1 -> {
-			if ((this.transactionAmount < 30_000) && (this.account.getFreeCount() >= this.MAX_FREE_COUNT)) {
-				this.trueCharge();
-			}
-		}
-		case 2 -> {
-			if (this.account.getFreeCount() >= this.MAX_FREE_COUNT) {
-				this.trueCharge();
-			}
-		}
-		}
-	}
+//	public void judge(int transactionCode) {
+//		switch (transactionCode) {
+//		case 1 -> {
+//			if ((this.transactionAmount < 30_000) && (this.account.getFreeCount() >= this.MAX_FREE_COUNT)) {
+//				this.trueCharge();
+//			}
+//		}
+//		case 2 -> {
+//			if (this.account.getFreeCount() >= this.MAX_FREE_COUNT) {
+//				this.trueCharge();
+//			}
+//		}
+//		}
+//	}
 
 	//入力した金額の確認
 	public void check(int transactionCode) {
@@ -388,6 +404,7 @@ public class ATM implements BankTeller{
 		this.setTransaction("取引なし");
 		this.setTransactionCode(0);
 		this.setTransactionAmount(0);
+		this.falseCharge();
 		this.falseTrade();
 	}
 

--- a/ATMsystem/Account.java
+++ b/ATMsystem/Account.java
@@ -13,7 +13,8 @@ public class Account {
 	public Account(String name, int balance) {
 		this.setName(name);
 		this.setBalance(balance);
-		this.setFreeCount(0);
+		//無料取引回数と最終利用日の設定
+		this.setFreeCount(3);
 		this.setDateOfLastUse(LocalDate.of(2024, 1, 8));
 	}
 
@@ -68,12 +69,16 @@ public class Account {
 	public int getFreeCount() {
 		return this.freeCount;
 	}
-
+	//初期設定用
 	public void setFreeCount(int freeCount) {
 		if (freeCount < 0) {
 			throw new IllegalArgumentException("freeCountは0以上で設定してください");
 		}
 		this.freeCount = freeCount;
+	}
+	//カウント用（オーバーロード）
+	public void setFreeCount() {
+		this.freeCount++;
 	}
 
 	public LocalDate getDateOfLastUse() {

--- a/ATMsystem/Bankbook.java
+++ b/ATMsystem/Bankbook.java
@@ -9,69 +9,83 @@ import java.util.Map;
 public class Bankbook {
 	Account account;
 	ATM atm;
+	final String[] COLUMN = { "年月日", "お預り金額", "お支払金額", "現在高" };
+	final String FORMAT = "%,13d";
 	Map<String, Object> log;
 	List<Map<String, Object>> bankbook;
 
 	//コンストラクタ
-	public Bankbook(Account account,ATM atm) {
+	public Bankbook(Account account, ATM atm) {
 		this.account = account;
 		this.atm = atm;
 		this.log = new LinkedHashMap<String, Object>();
-		this.log.put("年月日", LocalDate.of(2024, 1, 8));
-//		this.log.put("取扱店", null);
-		this.log.put("お預り金額", String.format("%,11d", account.getBalance()));
-		this.log.put("お支払金額", " (新規)    ");
-		this.log.put("現在高", String.format("%,11d", account.getBalance()));
-		
+		this.log.put(COLUMN[0], LocalDate.of(2024, 1, 8));
+		this.log.put(COLUMN[1], String.format(FORMAT, account.getBalance()));
+		this.log.put(COLUMN[2], "  (新規)    ");
+		this.log.put(COLUMN[3], String.format(FORMAT, account.getBalance()));
 		this.bankbook = new LinkedList<Map<String, Object>>();
 		this.bankbook.add(log);
 	}
-	
+
 	//メゾット
 	//記帳
 	public void recording() {
 		Map<String, Object> newlog = new LinkedHashMap<String, Object>();
-		
+
 		//手数料がかかる場合
-		if(this.atm.getCharge()) {
+		if (this.atm.getCharge()) {
 			//1行目に手数料加算前の取引を記入
-			newlog.put("年月日", this.account.getDateOfLastUse());
-			if(this.atm.getTransactionCode()==1) {
-				newlog.put("お預り金額", String.format("%,11d", this.atm.getTransactionAmount()));
-				newlog.put("お支払金額", " (ATM入金) ");
-			} else if(this.atm.getTransactionCode()==2) {
-				newlog.put("お預り金額", " (ATM出金) ");
-				newlog.put("お支払金額", String.format("%,11d", this.atm.getTransactionAmount()));
+			newlog.put(COLUMN[0], this.account.getDateOfLastUse());
+			if (this.atm.getTransactionCode() == 1) {
+				newlog.put(COLUMN[1], String.format(FORMAT, this.atm.getTransactionAmount()));
+				newlog.put(COLUMN[2], "  (ATM入金) ");
+			} else if (this.atm.getTransactionCode() == 2) {
+				newlog.put(COLUMN[1], "  (ATM出金) ");
+				newlog.put(COLUMN[2], String.format(FORMAT, this.atm.getTransactionAmount()));
 			}
-			newlog.put("現在高", String.format("%,11d", this.account.getBalance()+this.atm.HANDLING_CHARGE));
+			newlog.put(COLUMN[3], String.format(FORMAT, this.account.getBalance() + this.atm.HANDLING_CHARGE));
 			this.bankbook.add(newlog);
 			//2行目に手数料を記入
 			Map<String, Object> newlogCharge = new LinkedHashMap<String, Object>();
-			newlogCharge.put("年月日", this.account.getDateOfLastUse());
-			newlogCharge.put("お預り金額", " (手数料)  ");
-			newlogCharge.put("お支払金額", String.format("%,11d", this.atm.HANDLING_CHARGE));
-			newlogCharge.put("現在高", String.format("%,11d", this.account.getBalance()));
+			newlogCharge.put(COLUMN[0], this.account.getDateOfLastUse());
+			newlogCharge.put(COLUMN[1], "  (手数料)  ");
+			newlogCharge.put(COLUMN[2], String.format(FORMAT, this.atm.HANDLING_CHARGE));
+			newlogCharge.put(COLUMN[3], String.format(FORMAT, this.account.getBalance()));
 			this.bankbook.add(newlogCharge);
 		} else {
 			//手数料がかからない場合
-			newlog.put("年月日", this.account.getDateOfLastUse());
-			if(this.atm.getTransactionCode()==1) {
-				newlog.put("お預り金額", String.format("%,11d", this.atm.getTransactionAmount()));
-				newlog.put("お支払金額", " (ATM入金) ");
-			} else if(this.atm.getTransactionCode()==2) {
-				newlog.put("お預り金額", " (ATM出金) ");
-				newlog.put("お支払金額", String.format("%,11d", this.atm.getTransactionAmount()));
+			newlog.put(COLUMN[0], this.account.getDateOfLastUse());
+			if (this.atm.getTransactionCode() == 1) {
+				newlog.put(COLUMN[1], String.format(FORMAT, this.atm.getTransactionAmount()));
+				newlog.put(COLUMN[2], "  (ATM入金) ");
+			} else if (this.atm.getTransactionCode() == 2) {
+				newlog.put(COLUMN[1], "  (ATM出金) ");
+				newlog.put(COLUMN[2], String.format(FORMAT, this.atm.getTransactionAmount()));
 			}
-			newlog.put("現在高", String.format("%,11d", this.account.getBalance()));
+			newlog.put(COLUMN[3], String.format(FORMAT, this.account.getBalance()));
 			this.bankbook.add(newlog);
 		}
-		
+
 	}
+
 	//記帳内容の表示
 	public void disp() {
-		for(Object list : this.bankbook) {
-			System.out.print(list+" ");
-			System.out.println();
+		//【1】{Key=Value}の形で表示
+//			for(Object list : this.bankbook) {
+//				System.out.println(list);
+//			}
+		
+		//【2】1行目にKey、2行目以降にValueを表示
+		for (String c : COLUMN) {
+			System.out.print(String.format("【%s】 ", c));
+		}
+		System.out.println("");
+		for (Map<String, Object> m : this.bankbook) {
+			for (String key : m.keySet()) {
+				Object value = m.get(key);
+				System.out.print(value + " ");
+			}
+			System.out.println("");
 		}
 	}
 }


### PR DESCRIPTION
・ATMクラス
　judgeメゾットをsetChargeメゾット（chargeフィールドのセッター）に書き換え
　取引終了後にchargeフィールドを初期化
・Accountクラス
　引数無しのsetFreeCountメゾットを追加（オーバーロード）
・Bankbookクラス
　通帳の項目と金額表示フォーマットを定数として宣言
　dispメゾットの修正